### PR TITLE
Fixed equality compare of deploymentKind.

### DIFF
--- a/charts/hcloud-fip-controller/templates/deployment.yaml
+++ b/charts/hcloud-fip-controller/templates/deployment.yaml
@@ -5,13 +5,13 @@ metadata:
   labels:
     {{- include "hcloud-fip-controller.labels" . | nindent 4 }}
 spec:
-{{- if .Values.deploymentKind == "Deployment" }}
+{{- if eq .Values.deploymentKind "Deployment" }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}
   selector:
     matchLabels:
       {{- include "hcloud-fip-controller.selectorLabels" . | nindent 6 }}
-{{- if .Values.deploymentKind == "Deployment" }}
+{{- if eq .Values.deploymentKind "Deployment" }}
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Previously to this fix helm gave me the following error:
`Error: parse error at (hcloud-fip-controller/templates/deployment.yaml:8): unexpected "=" in operand`.

This pull request fix the error and allows for hcloud-fip-controller to be deployed as DaemonSet.

Kind regards,
Florian