### PR TITLE
Fix syntax error in helpers

### DIFF
--- a/charts/hcloud-fip-controller/templates/_helpers.tpl
+++ b/charts/hcloud-fip-controller/templates/_helpers.tpl
@@ -71,6 +71,7 @@ Create the name of the settings ConfigMap to use.
 {{- else -}}
     {{ .Values.existingConfigMap }}
 {{- end -}}
+{{- end -}}
 
 {{/*
 Create the name of the environment Secret to use.


### PR DESCRIPTION
There is a missing end statement, which causes a syntax error and renders the chart unusable.