### PR TITLE
Add missing space in helpers

### DIFF
--- a/charts/hcloud-fip-controller/templates/_helpers.tpl
+++ b/charts/hcloud-fip-controller/templates/_helpers.tpl
@@ -77,7 +77,7 @@ Create the name of the settings ConfigMap to use.
 Create the name of the environment Secret to use.
 */}}
 {{- define "hcloud-fip-controller.envSecretName" -}}
-{{- if .Values.secretInline-}}
+{{- if .Values.secretInline -}}
     {{ include "hcloud-fip-controller.fullname" . }}
 {{- else -}}
     {{ .Values.existingEnvSecret }}


### PR DESCRIPTION
There was missing space in the helpers template, that caused the chart to be unsuable, as it would produce a syntax error.